### PR TITLE
check date format

### DIFF
--- a/ExcelMerge/ExcelUtility.cs
+++ b/ExcelMerge/ExcelUtility.cs
@@ -23,7 +23,14 @@ namespace ExcelMerge
                 switch (type)
                 {
                     case CellType.Numeric:
-                        return cell.NumericCellValue;
+                        if (DateUtil.IsCellDateFormatted(cell))
+                        {
+                            return cell.DateCellValue;
+                        }
+                        else
+                        {
+                            return cell.NumericCellValue;
+                        }
                     case CellType.String:
                         return cell.StringCellValue;
                     case CellType.Boolean:


### PR DESCRIPTION
Since the date cell was displayed as a numerical value, we checked the date format so that it is displayed as a date.

When using a custom format, it seems that it may remain as a number, but in many cases this should correctly display it.

日付セルが数値として表示されていたので、日付フォーマットをチェックして日付として表示されるようにしました。

カスタムフォーマットを使った場合数値のままになってしまう場合もあるようですが、多くの場合はこの修正で正しく表示できるはずです。
